### PR TITLE
style: Adicionar estilos iniciais usando Tailwind CSS.

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+    @apply bg-gray-900 h-full overflow-x-hidden;
+}
+
+#--next {
+    @apply h-full;
+}
+
+html {
+    @apply h-full;
+}


### PR DESCRIPTION
Neste commit, adicionei estilos iniciais ao projeto usando o Tailwind CSS. Utilizei as diretivas @tailwind para incluir os estilos base, componentes e utilitários fornecidos pelo Tailwind. O estilo do corpo (body) foi configurado com uma cor de fundo cinza escuro (#333333) e altura completa (h-full), além de evitar a rolagem horizontal (overflow-x-hidden). Também foi aplicado a classe h-full aos elementos com os IDs #--next e ao elemento html para garantir que eles ocupem toda a altura do elemento pai, o que permite criar uma estrutura de layout com altura completa de forma rápida e eficiente.